### PR TITLE
install_requires is not recognized by distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='OrderBook',


### PR DESCRIPTION
After applying this change, the dependencies listed under `install_requires` will be installed when running `python setup.py install`.